### PR TITLE
Update versions of container and openshift

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM httpd:2.4
 
-ENV DEBIAN_FRONTEND noninterative
+ENV DEBIAN_FRONTEND noninteractive
 ENV FQDN localhost
 ENV USER_NAME smtp
 ENV USER_ID 10001

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ ENV APACHE_RUN_GROUP smtp
 RUN echo "#!/bin/sh\nexit 0" > /usr/sbin/policy-rc.d
 
 RUN apt-get update && \
+    apt-get install apt-utils && \
     apt-get install -y --no-install-recommends postfix courier-base sqwebmail courier-imap && \
     apt-get autoremove -y && \
     rm -fr /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,24 @@ ENV APACHE_RUN_GROUP smtp
 
 RUN echo "#!/bin/sh\nexit 0" > /usr/sbin/policy-rc.d
 
+# filthy hack, see https://bugs.launchpad.net/ubuntu/+source/courier/+bug/1781243
+RUN mkdir -p /usr/share/man/man1 \
+    /usr/share/man/man5 \
+    /usr/share/man/man7 \
+    /usr/share/man/man8 && \
+    touch /usr/share/man/man1/lockmail.1.gz \
+    /usr/share/man/man1/maildirmake.courier.1.gz \
+    /usr/share/man/man1/maildirmake.maildrop.1.gz \
+    /usr/share/man/man1/makedat.courier.1.gz \
+    /usr/share/man/man5/maildir.courier.5.gz \
+    /usr/share/man/man5/maildir.maildrop.5.gz \
+    /usr/share/man/man7/maildirquota.courier.7.gz \
+    /usr/share/man/man7/maildirquota.maildrop.7.gz \
+    /usr/share/man/man8/deliverquota.courier.8.gz \
+    /usr/share/man/man8/deliverquota.maildrop.8.gz
+
 RUN apt-get update && \
-    apt-get install apt-utils && \
+    apt-get install -y --no-install-recommends maildrop && \
     apt-get install -y --no-install-recommends postfix courier-base sqwebmail courier-imap && \
     apt-get autoremove -y && \
     rm -fr /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM httpd:2.2
+FROM httpd:2.4
 
 ENV DEBIAN_FRONTEND noninterative
 ENV FQDN localhost

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Download and extract the latest openshift tools from [openshift.org](https://www
 into the working directory.
 
 ```bash
-$ wget https://github.com/openshift/origin/releases/download/v3.9.0/openshift-origin-client-tools-v3.9.0-191fece-linux-64bit.tar.gz
-$ tar -xf openshift-origin-client-tools-v3.9.0-191fece-linux-64bit.tar.gz \
+$ wget https://github.com/openshift/origin/releases/download/v3.11.0/openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz
+$ tar -xf openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz \
   --wildcards --no-anchored --strip-components 1 '*/oc'
 ```
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,6 +13,7 @@ Vagrant.configure("2") do |config|
     vb.memory = "8192"
   end
   config.vm.provision "shell", inline: <<-SHELL
+    echo 'export PATH=$PATH:/usr/local/bin' >/etc/profile.d/usr_bin.sh
     export PATH=$PATH:/usr/local/bin
     cp /vagrant/oc /usr/local/bin/
     yum install -y docker

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,6 +16,7 @@ Vagrant.configure("2") do |config|
     echo 'export PATH=$PATH:/usr/local/bin' >/etc/profile.d/usr_bin.sh
     export PATH=$PATH:/usr/local/bin
     cp /vagrant/oc /usr/local/bin/
+    chmod 755 /usr/local/bin/oc
     yum install -y docker
     echo '{ "insecure-registries": [ "172.30.0.0/16" ] }' >/etc/docker/daemon.json
     systemctl enable docker

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,7 +17,7 @@ Vagrant.configure("2") do |config|
     export PATH=$PATH:/usr/local/bin
     cp /vagrant/oc /usr/local/bin/
     chmod 755 /usr/local/bin/oc
-    yum install -y docker
+    yum install -y docker git
     echo '{ "insecure-registries": [ "172.30.0.0/16" ] }' >/etc/docker/daemon.json
     systemctl enable docker
     systemctl start docker


### PR DESCRIPTION
1. Builds of containers based on Jessie are failing across the world due to it being archived by Debian, so this PR bumps the version used to Debian 9 (Stretch).
2. Bump version of openshift from 3.9 to 3.11
3. Fix a few typos